### PR TITLE
changing shuttle sticker to nasa

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -6,7 +6,7 @@
 	--rocket-launch-countdown: 1s;
 
 	/* shuttle config */
-	--shuttle-logo: var(--shuttle-logo-jpl);
+	--shuttle-logo: var(--shuttle-logo-nasa);
 	--rocket-fuel: 0;
 }
 


### PR DESCRIPTION
According to NASA One, the sticker must be NASA, not a division this fixes #2